### PR TITLE
Fix NodeJS example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The script takes three arguments:
 
 ```bash
 node nodejs-request/index.js \
-    'ttl.sh/hello-world-node:1h'
+    'ttl.sh/hello-world-node:1h' \
     ./hello-world \
     node17
 ```


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

## Description

Add missing `\` in example command for NodeJS.

## Context

Copy pasting command failed while using the examples for testing the pro-builder E2E.
