### PR TITLE
Update the go example to use the OpenFaaS go-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ kubectl get secret \
 The directory [hello-world](./hello-world/) can be passed as the handler directory to the examples. It contains a javascript handler for a function. The hello-world directory was created by running:
 
 ```bash
-faas-cli new hello-world --lang node17
+faas-cli new hello-world --lang node20
 ```
 
 You can use the `faas-cli` to create any other handler to try these example scripts with.
@@ -43,7 +43,7 @@ Run the script
 python3 python-request/build.py \
     --image ttl.sh/hello-world-python:1h \
     --handler ./hello-world \
-    --lang node17
+    --lang node20
 ```
 
 ## Use NodeJS to call the pro-builder
@@ -64,7 +64,7 @@ The script takes three arguments:
 node nodejs-request/index.js \
     'ttl.sh/hello-world-node:1h' \
     ./hello-world \
-    node17
+    node20
 ```
 
 ## Use php to call the pro-builder
@@ -85,16 +85,25 @@ The script takes three arguments:
 php php-request/build.php \
     --image=ttl.sh/hello-world-php:1h \
     --handler=./hello-world \
-    --lang=node17
+    --lang=node20
 ```
 
-## Use go to call the pro-builder
-The [go-request](./go-request/) directory has an example on how to invoke the Function Builder API from go. Run the `main.go` script with the required flags to turn a function handler into a container image.
+## Use go and the OpenFaaS go-sdk to call the pro-builder
+The [go-request](./go-request/) directory has an example on how to invoke the Function Builder API from go using the official OpenFaaS go-sdk. Run the `main.go` script with the required flags to turn a function handler into a container image.
+
+The example script does not fetch templates. How this is done is up to your implementation. Templates can be pulled from a git repository, copied from an S3 bucket, downloaded with an http call.
+
+To try out this example you can fetch them using the faas-cli before running the script:
+```sh
+faas-cli template store pull node20
+```
 
 Run the script
 ```bash
 go run go-request/main.go \
     -image=ttl.sh/hello-world-go:1h \
     -handler=./hello-world \
-    -lang=node17
+    -lang=node20 \
+    -name="hello-world" \
+    -platforms="linux/amd64"
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/openfaas/function-builder-examples
 
-go 1.18
+go 1.21
 
-require github.com/alexellis/hmac/v2 v2.0.0
+toolchain go1.22.1
+
+require github.com/openfaas/go-sdk v0.2.14
+
+require github.com/alexellis/hmac/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/alexellis/hmac/v2 v2.0.0 h1:/sH/UJxDXPpJorUeg2DudeKSeUrWPF32Yamw2TiDoOQ=
 github.com/alexellis/hmac/v2 v2.0.0/go.mod h1:O7hZZgTfh5fp5+vAamzodZPlbw+aQK+nnrrJNHsEvL0=
+github.com/openfaas/go-sdk v0.2.14 h1:N3bq0yparYZR6pR1AhZiPGvV8GAmQ1UfjmCOGaZMs68=
+github.com/openfaas/go-sdk v0.2.14/go.mod h1:DrKUCQ4F8L2cJOmWHNoX8zB8LQIZc/4hRgAtT4t0s4k=

--- a/nodejs-request/package-lock.json
+++ b/nodejs-request/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "nodejs-request",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/php-request/build.php
+++ b/php-request/build.php
@@ -71,7 +71,7 @@ $cli = new Cli();
 $cli->description('Build a function with the OpenFaaS Pro Builder')
     ->opt('image:i', 'Docker image name to build, e.g. docker.io/functions/hello-world:0.1.0', true)
     ->opt('handler:h', 'Directory with handler for function, e.g. ./hello-world', true)
-    ->opt('lang:l', 'Language or template to use, e.g. node17', true);
+    ->opt('lang:l', 'Language or template to use, e.g. node20', true);
 
 // Parse and return cli args.
 $args        = $cli->parse($argv, true);

--- a/python-request/build.py
+++ b/python-request/build.py
@@ -57,7 +57,7 @@ parser.add_argument('--image', type=str,
 parser.add_argument('--handler', type=str,
                     help="Directory with handler for function, e.g. handler.js", required=True)
 parser.add_argument('--lang', type=str,
-                    help="Language or template to use, e.g. node17", required=True)
+                    help="Language or template to use, e.g. node20", required=True)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
## Description

Update the go example to use the OpenFaaS go-sdk

## Motivation and context

Show how to use the  new builder package that was recently added to the [go-sdk](https://github.com/openfaas/go-sdk) in the golang example.

## How has this been tested

Used the commands provided in the README to test the golang script locally.